### PR TITLE
add google tag manager

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -53,9 +53,20 @@ under the License.
       $(function() { setupCodeCopy(); });
     </script>
     <% end %>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-NQ97GBL');</script>
+    <!-- End Google Tag Manager -->
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NQ97GBL“
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <a href="#" id="nav-button">
       <span>
         NAV


### PR DESCRIPTION
Add google tag manager requested by bapak aji putra, related docs:
https://oyteam.quip.com/54XsAREjW1wl/Website-Tracker-Implementation

tanpa implementasi ini ketika user melakukan:
akses halaman https://oyindonesia.com/id/bisnis/, lalu
pergi ke halaman api-docs dari menu yang tersedia di sana

more info:
https://support.google.com/tagmanager/answer/6164469?hl=en