### PR TITLE
change balances description on get child balance

### DIFF
--- a/source/includes/_api_multi_account_management.md
+++ b/source/includes/_api_multi_account_management.md
@@ -462,7 +462,7 @@ Parameter | Type | Description
 --------- | ---- | -----------
 status | Object | Status of Request in Object `{code: <status_code>, message: <status_message>}`
 data | Object | Response data `{balances: <balances>, timeStamp: <timeStamp>}`
-balances | Array of Objects | List of Objects `{username: <username>, balance: <balance>, overdraftBalance: <overdraftBalance>, overbookingBalance: <overbookingBalance>, pendingBalance: <pendingBalance>, availableBalance: <availableBalance>}`
+balances | Array of Objects | List of Objects consist of `username` of the child, `balance`, `overdraftBalance`, `overbookingBalance`, `pendingBalance`, and `availableBalance`
 username | String(255) | Child username whom balance info is returned
 balance | BigDecimal | Remaining balance (Accept non fraction number)
 overdraftBalance | BigDecimal | Remaining overdraft balance (Accept non fraction number)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
change `balances` description to reduce scrolling on get child balance response parameter table.
![image](https://user-images.githubusercontent.com/31226068/149070343-4938af79-50d8-43a9-994f-40fc70293cc3.png)

Before:
![image](https://user-images.githubusercontent.com/31226068/149071587-eadaeae9-fd72-41fe-a22a-68fc0ce16af7.png)

