### PR TITLE
[Disbursement Bank Codes] remove maybank syariah from bank codes

### DIFF
--- a/source/includes/_disbursement_banks.md
+++ b/source/includes/_disbursement_banks.md
@@ -12,7 +12,6 @@ Bank Codes | Bank Name
 013 | Bank Permata Syariah
 014	| Bank BCA
 016	| BII Maybank
-016 | Maybank Syariah
 019	| Bank Panin
 022	| CIMB Niaga
 023	| Bank UOB INDONESIA


### PR DESCRIPTION
remove maybank syariah from bank codes since it has incorrect bank code (016), should be (947). and is currently not supported by us