### PR TITLE
Set ubuntu version to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    # See PR description about the reason of using 20.04
+    # See https://github.com/oyindonesia/external-api-docs/pull/189 about the reason of using 20.04
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    # See PR description about the reason of using 20.04
+    # See https://github.com/oyindonesia/external-api-docs/pull/189 about the reason of using 20.04
     runs-on: ubuntu-20.04
     env:
       ruby-version: 2.5

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    # See PR description about the reason of using 20.04
+    # See https://github.com/oyindonesia/external-api-docs/pull/189 about the reason of using 20.04
     runs-on: ubuntu-20.04
     env:
       ruby-version: 2.5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    # See PR description about the reason of using 20.04
+    # See https://github.com/oyindonesia/external-api-docs/pull/189 about the reason of using 20.04
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Set ubuntu version to 20.04

Currently it fails to build
```
bundler: failed to load command: middleman (/home/runner/work/oybayar-docs/oybayar-docs/vendor/bundle/ruby/2.6.0/bin/middleman)
LoadError: libffi.so.7: cannot open shared object file: No such file or directory - /home/runner/work/oybayar-docs/oybayar-docs/vendor/bundle/ruby/2.6.0/gems/ffi-1.13.1/lib/ffi_c.so

```

After comparing github actions log of successful vs failed commit, we see that the successful one use 20.04 while the failed one use 20.04. It might be related with https://github.com/rbenv/ruby-build/discussions/1940#discussioncomment-2519546