### PR TITLE
Update Payment and Inquiry Information for BSI VAs

### DIFF
--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -308,10 +308,13 @@ Endpoint:
 |trx_expiration_time|Date string; yyyy-MM-dd HH:mm:ss format|Trasnaction Expiration Time|
 |payment_info|Object|Payment info object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number`)|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ### List of Disbursement Mock Account for Testing Purpose 
 Use those mock receiver bank account for testing Payment Routing purpose. To simulate all available status of Payment Routing, you can combine those mocked bank account numbers. For example, if you want to see `INCOMPLETE` status, put two recipients in the payment_routing object with mocked bank account number `1234567890` and `1234567891`. For more information about payment Routing status, see List of Payment Routing section.
@@ -567,7 +570,7 @@ Endpoint:
 |need_frontend|Boolean|Partner need UI or not, if true, we will route to payment link, otherwise will be route to va aggregator.|
 |payment_info|Object|Payment info Object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number`)|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 |payment_routing|List of Object|List of payment routing recipients. See row belows|
@@ -580,6 +583,10 @@ Endpoint:
 |disbursement_trx_notes|String|Disbursement Transaction notes|
 |disbursement_trx_status|String|Disbursement transaction status. See List of Disbursement Status below|
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
+
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ## Partner Callback Payment Routing
 Once user successfully do the payment, our system will make a callback via HTTP POST request to your system
@@ -623,7 +630,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
 |need_frontend|Boolean|Partner need UI or not, if true, we will route to payment link, otherwise will be route to va aggregator.|
 |payment_info|Object|Payment info Object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` received (remove `6059` from the `va_number`)|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 |payment_routing|List of Object|List of payment routing recipients. See row belows|
@@ -636,6 +643,10 @@ Once user successfully do the payment, our system will make a callback via HTTP 
 |disbursement_trx_notes|String|Disbursement Transaction notes|
 |disbursement_trx_status|String|Disbursement transaction status. See List of Disbursement Status below|
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
+
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ## List of Payment Routing Status
 | Status               | Description                                                                                                                                            |

--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -313,7 +313,7 @@ Endpoint:
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ### List of Disbursement Mock Account for Testing Purpose 
@@ -585,7 +585,7 @@ Endpoint:
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ## Partner Callback Payment Routing
@@ -645,7 +645,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ## List of Payment Routing Status

--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -308,7 +308,7 @@ Endpoint:
 |trx_expiration_time|Date string; yyyy-MM-dd HH:mm:ss format|Trasnaction Expiration Time|
 |payment_info|Object|Payment info object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number`)|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 
@@ -567,7 +567,7 @@ Endpoint:
 |need_frontend|Boolean|Partner need UI or not, if true, we will route to payment link, otherwise will be route to va aggregator.|
 |payment_info|Object|Payment info Object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number`)|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 |payment_routing|List of Object|List of payment routing recipients. See row belows|
@@ -623,7 +623,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
 |need_frontend|Boolean|Partner need UI or not, if true, we will route to payment link, otherwise will be route to va aggregator.|
 |payment_info|Object|Payment info Object|
 |payment_checkout_url|String|generated url for payment link; conditional, only exist if request need_frontend is TRUE|
-|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
+|va_number|String|Generated VA number; conditional, only exist if request need_frontend is FALSE and payment_method is VA. For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` received (remove `6059` from the `va_number`)|
 |va_display_name|String|VA display name; conditional, only exist if request need_frontend is FALSE and payment_method is VA|
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 |payment_routing|List of Object|List of payment routing recipients. See row belows|

--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -313,7 +313,7 @@ Endpoint:
 |qris_url|String|the URL of QR image; conditional, only exist if request need_frontend is FALSE and payment_method is QRIS|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ### List of Disbursement Mock Account for Testing Purpose 
@@ -585,7 +585,7 @@ Endpoint:
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ## Partner Callback Payment Routing
@@ -645,7 +645,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
 |email_status|String|Email sending status; Possible status:- SENT- UNSENT|
 
 <aside class="warning">
-Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` (remove `6059` from the `va_number` which has the form `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries involving a BSI VA using other methods
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the VA Number (remove 6059 from the VA number which has the form "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
 </aside>
 
 ## List of Payment Routing Status

--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -299,6 +299,9 @@ partner_trx_id | String(255) | Partner unique Transaction ID of a VA
 trx_counter | Int | Transaction counter to limit number of transaction that can be receive by va number, if empty will be use default value -1 for multiple use va, and 1 for single use va. If counter reach zero, va cannot be inquiry or accept payment.
 counter_incoming_payment | Integer | Count total incoming payment of VA
 
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ## Get VA Info
 
@@ -513,6 +516,9 @@ trx_expiration_time | Long | Transaction expiration time on Unix timestamp in mi
 partner_trx_id | String(255) | Partner unique Transaction ID of a VA
 trx_counter | Int | Transaction counter to limit number of transaction that can be receive by va number, if empty will be use default value -1 for multiple use va, and 1 for single use va. If counter reach zero, va cannot be inquiry or accept payment.
 
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ## Update VA
 
@@ -1263,8 +1269,9 @@ trx_id | String (255) | Unique ID of incoming payment
 settlement_time | Timestamp | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 settlement_status | String(255) | The status of the settlement
 
-#### Important Note for BSI VAs
-For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` received (remove `6059` from the `va_number` with format `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries using other methods.
+<aside class="warning">
+Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number (remove 6059 from the va_number with format "6059xxxxxxxxxxxx"). This does not apply to payments and inquiries involving a BSI VA using other methods
+</aside>
 
 ## VA aggregator Bank Code
 ### Available Bank for VA aggregator

--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -1263,8 +1263,8 @@ trx_id | String (255) | Unique ID of incoming payment
 settlement_time | Timestamp | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 settlement_status | String(255) | The status of the settlement
 
-#### Special Note for BSI VAs
-For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number received (remove 6059 from the va_number).
+#### Important Note for BSI VAs
+For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the `va_number` received (remove `6059` from the `va_number` with format `6059xxxxxxxxxxxx`). This does not apply to payments and inquiries using other methods.
 
 ## VA aggregator Bank Code
 ### Available Bank for VA aggregator

--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -1263,6 +1263,9 @@ trx_id | String (255) | Unique ID of incoming payment
 settlement_time | Timestamp | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 settlement_status | String(255) | The status of the settlement
 
+#### Special Note for BSI VAs
+For payments and inquiries involving a BSI VA using BSI Mobile or Banking Syariah Indonesia Net, please only input the last 12 digits of the va_number received (remove 6059 from the va_number).
+
 ## VA aggregator Bank Code
 ### Available Bank for VA aggregator
 


### PR DESCRIPTION
Updates payment and inquiry info for BSI VAs, since payments and inquiries involving a BSI VA made using BSI Mobile or Banking Syariah Indonesia Net requires the user to only input the last 12 digits of the va number we sent back (basically remove the 6059 part from the beginning of the va number).