### PR TITLE
Remove gem update Command from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ jobs:
           gems-${{ runner.os }}-${{ matrix.ruby-version }}-
           gems-${{ runner.os }}-
 
-    # necessary to get ruby 2.3 to work nicely with bundler vendor/bundle cache
-    # can remove once ruby 2.3 is no longer supported
-    - run: gem update --system
-
     - run: bundle config set deployment 'true'
     - name: bundle install
       run: |


### PR DESCRIPTION
Removes `gem update --system` since it has been causing some issues in CI. Context in slack: https://oyteam.slack.com/archives/C01N68XN3K2/p1672034918063539?thread_ts=1671519789.594199&cid=C01N68XN3K2