### PR TITLE
[Payment Routing] Add Separate Callback Examples per Payment Method for Payment Routing

### DIFF
--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -676,6 +676,34 @@ Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking 
 ## Partner Callback Payment Routing
 Once user successfully do the payment, our system will make a callback via HTTP POST request to your system
 
+> Callback Structure for Payment Link (need_frontend = true)
+
+```json
+{
+    "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
+    "partner_trx_id": "TRX-20211117-1030",
+    "receive_amount": 14000,
+    "payment_status": "WAITING_PAYMENT",
+    "trx_expiration_time": "2021-12-02 18:59:31",
+    "need_frontend": false,
+    "payment_method": "VA",
+    "sender_bank": "009",
+    "payment_info": {
+        "payment_checkout_url": "https://pay.oyindonesia.com/12345678-9012-3456-7890-123456789012"
+    },
+    "payment_routing": [
+        {
+            "recipient_bank": "014",
+            "recipient_account": "1234567890",
+            "recipient_account_name": "Katelin Bode",
+            "recipient_amount": 10000.0000,
+            "disbursement_trx_id": "35ff4e6b-e240-44b3-aff1-1151289e912e",
+            "trx_status": "WAITING"
+        }
+    ]
+}
+```
+
 > Callback Structure for VA
 
 ```json

--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -755,7 +755,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
     "payment_method": "QRIS",
     "sender_bank": "QRIS",
     "payment_info": {
-        "qris_url": "https://mapi.gw.airpay.co.id/v3/merchant-host/qr/download?qr=12Z4Z4TQkIrhgdjQgusVlinghaja2GnDjrjWKN89",
+        "qris_url": "https://qris.url.com",
         "payment_reference_number": "120345030342784191"
     },
     "payment_routing": [
@@ -784,7 +784,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
     "payment_method": "EWALLET",
     "sender_bank": "dana_ewallet",
     "payment_info": {
-        "ewallet_url": "https://link.dana.id/pay?bizNo=123&timestamp=1700000000000&originSourcePlatform=IPG&mid=123&did=123&sign=sign&forceToH5=false"
+        "ewallet_url": "https://ewallet.url.com"
     },
     "payment_routing": [
         {
@@ -812,7 +812,7 @@ Once user successfully do the payment, our system will make a callback via HTTP 
     "payment_method": "CARDS",
     "sender_bank": "CC_DC",
     "payment_info": {
-        "card_url": "https://payment.mcpayment.id/en/a3BNtpHJic3RK4ozZ8N7Hn"
+        "card_url": "https://ccdc.link.com"
     },
     "payment_routing": [
         {

--- a/source/includes/_payment_routing.md
+++ b/source/includes/_payment_routing.md
@@ -676,6 +676,8 @@ Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking 
 ## Partner Callback Payment Routing
 Once user successfully do the payment, our system will make a callback via HTTP POST request to your system
 
+> Callback Structure for VA
+
 ```json
 {
     "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
@@ -688,8 +690,129 @@ Once user successfully do the payment, our system will make a callback via HTTP 
     "payment_method": "VA",
     "sender_bank": "009",
     "payment_info": {
-        "va_number": "103406000000006289",
-        "va_display_name": "partner_brand"
+        "account_number": "103406000000006289",
+        "account_name": "partner_brand",
+        "bank_code": "009"
+    },
+    "payment_routing": [
+        {
+            "recipient_bank": "014",
+            "recipient_account": "1234567890",
+            "recipient_account_name": "Katelin Bode",
+            "recipient_amount": 10000.0000,
+            "disbursement_trx_id": "35ff4e6b-e240-44b3-aff1-1151289e912e",
+            "trx_status": "WAITING"
+        }
+    ]
+}
+```
+
+> Callback Structure for Unique Code
+
+```json
+{
+    "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
+    "partner_trx_id": "TRX-20211117-1030",
+    "receive_amount": 14000,
+    "payment_status": "WAITING_PAYMENT",
+    "trx_expiration_time": "2021-12-02 18:59:31",
+    "need_frontend": false,
+    "payment_method": "BANK_TRANSFER",
+    "sender_bank": "014",
+    "payment_info": {
+        "account_number": "123",
+        "account_name": "PT. Dompet Harapan Bangsa",
+        "bank_code": "014",
+        "unique_code_detail": {
+            "amount": 14123,
+            "unique_code": 123,
+            "unique_amount": 14000
+        }
+    },
+    "payment_routing": [
+        {
+            "recipient_bank": "014",
+            "recipient_account": "1234567890",
+            "recipient_account_name": "Katelin Bode",
+            "recipient_amount": 10000.0000,
+            "disbursement_trx_id": "35ff4e6b-e240-44b3-aff1-1151289e912e",
+            "trx_status": "WAITING"
+        }
+    ]
+}
+```
+
+> Callback Structure for QRIS
+
+```json
+{
+    "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
+    "partner_trx_id": "TRX-20211117-1030",
+    "receive_amount": 14000,
+    "payment_status": "WAITING_PAYMENT",
+    "trx_expiration_time": "2021-12-02 18:59:31",
+    "need_frontend": false,
+    "payment_method": "QRIS",
+    "sender_bank": "QRIS",
+    "payment_info": {
+        "qris_url": "https://mapi.gw.airpay.co.id/v3/merchant-host/qr/download?qr=12Z4Z4TQkIrhgdjQgusVlinghaja2GnDjrjWKN89",
+        "payment_reference_number": "120345030342784191"
+    },
+    "payment_routing": [
+        {
+            "recipient_bank": "014",
+            "recipient_account": "1234567890",
+            "recipient_account_name": "Katelin Bode",
+            "recipient_amount": 10000.0000,
+            "disbursement_trx_id": "35ff4e6b-e240-44b3-aff1-1151289e912e",
+            "trx_status": "WAITING"
+        }
+    ]
+}
+```
+
+> Callback Structure for E-wallet
+
+```json
+{
+    "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
+    "partner_trx_id": "TRX-20211117-1030",
+    "receive_amount": 14000,
+    "payment_status": "WAITING_PAYMENT",
+    "trx_expiration_time": "2021-12-02 18:59:31",
+    "need_frontend": false,
+    "payment_method": "EWALLET",
+    "sender_bank": "dana_ewallet",
+    "payment_info": {
+        "ewallet_url": "https://link.dana.id/pay?bizNo=123&timestamp=1700000000000&originSourcePlatform=IPG&mid=123&did=123&sign=sign&forceToH5=false"
+    },
+    "payment_routing": [
+        {
+            "recipient_bank": "014",
+            "recipient_account": "1234567890",
+            "recipient_account_name": "Katelin Bode",
+            "recipient_amount": 10000.0000,
+            "disbursement_trx_id": "35ff4e6b-e240-44b3-aff1-1151289e912e",
+            "trx_status": "WAITING"
+        }
+    ]
+}
+```
+
+> Callback Structure for Cards
+
+```json
+{
+    "trx_id": "23a009f5-24ce-4567-96b3-03c42a0fb7ae",
+    "partner_trx_id": "TRX-20211117-1030",
+    "receive_amount": 14000,
+    "payment_status": "WAITING_PAYMENT",
+    "trx_expiration_time": "2021-12-02 18:59:31",
+    "need_frontend": false,
+    "payment_method": "CARDS",
+    "sender_bank": "CC_DC",
+    "payment_info": {
+        "card_url": "https://payment.mcpayment.id/en/a3BNtpHJic3RK4ozZ8N7Hn"
     },
     "payment_routing": [
         {


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
Adds new payment routing callback examples per payment method & update example for VA

<img width="374" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/8d9310b7-c5a3-4859-9339-b9e250b7e377">
<img width="402" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/3ea4079b-a55e-41eb-9e31-6bff1a5583cd">
<img width="385" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/2af12cc0-bc08-4363-bf69-545b46628412">
<img width="383" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/ecd0adb9-59af-4da6-9ef5-59452edc79da">
<img width="387" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/92977392-e594-4920-8ddf-5c6c1da1c506">
<img width="378" alt="image" src="https://github.com/oyindonesia/external-api-docs/assets/60346810/0099c903-3379-4670-bf48-437e332ec6a5">
