### PR TITLE
[VA Callback] Add Nullable Info Parameter trx_expiration_date

### DIFF
--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -1957,7 +1957,7 @@ partner_user_id | String(255) | FALSE | Unique ID provided by partner for specif
 success | boolean | FALSE | The status of the payment and it is always set to SUCCESS
 tx_date | Timestamp | FALSE | Incoming payment transaction date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 username_display | String(255) | FALSE | Customizable VA display name that will be seen by user. If partner did not provide the value on creation VA, then it will be using partner’s username
-trx_expiration_date | Long | FALSE | Transaction expiration date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
+trx_expiration_date | Long | FALSE | Transaction expiration date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`. For VA Lifetime, the value of this parameter will be null/empty
 partner_trx_id | String(255) | TRUE | Unique Transaction ID provided by partner on creation or update VA. This parameter will be empty if partner leave this parameter empty when creating or updating the VA
 trx_id | String (255) | FALSE | Unique ID of incoming payment
 settlement_time | Timestamp | FALSE | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`

--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -1957,10 +1957,10 @@ partner_user_id | String(255) | FALSE | Unique ID provided by partner for specif
 success | boolean | FALSE | The status of the payment and it is always set to SUCCESS
 tx_date | Timestamp | FALSE | Incoming payment transaction date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 username_display | String(255) | FALSE | Customizable VA display name that will be seen by user. If partner did not provide the value on creation VA, then it will be using partner’s username
-trx_expiration_date | Long | FALSE | Transaction expiration date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`. For VA Lifetime, the value of this parameter will be null/empty
+trx_expiration_date | Long | TRUE | Transaction expiration date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`. For VA Lifetime, the value of this parameter will be null/empty
 partner_trx_id | String(255) | TRUE | Unique Transaction ID provided by partner on creation or update VA. This parameter will be empty if partner leave this parameter empty when creating or updating the VA
 trx_id | String (255) | FALSE | Unique ID of incoming payment
-settlement_time | Timestamp | TRUE | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
+settlement_time | Timestamp | FALSE | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 settlement_status | String(255) | FALSE | The status of the settlement
 
 <aside class="warning">

--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -1960,7 +1960,7 @@ username_display | String(255) | FALSE | Customizable VA display name that will 
 trx_expiration_date | Long | FALSE | Transaction expiration date, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`. For VA Lifetime, the value of this parameter will be null/empty
 partner_trx_id | String(255) | TRUE | Unique Transaction ID provided by partner on creation or update VA. This parameter will be empty if partner leave this parameter empty when creating or updating the VA
 trx_id | String (255) | FALSE | Unique ID of incoming payment
-settlement_time | Timestamp | FALSE | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
+settlement_time | Timestamp | TRUE | The timestamp (in UTC+7) indicating when the fund will be settled to partner’s account statement, format `dd/MM/yyyy'T'HH:mm:ss.SSSZZZZ`
 settlement_status | String(255) | FALSE | The status of the settlement
 
 <aside class="warning">


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
[VA Callback] Add Nullable Info Parameter trx_expiration_date