### PR TITLE
fix: wrong va field to expire VA

### DIFF
--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -808,7 +808,7 @@ email | String(255) | TRUE | This parameter will only be sent if the value input
 full_name | String(255) | TRUE | If `full_name` is needed when creating the transaction, the inputted value at creation will be shown here. This parameter will only be sent if the value inputted in creation request. Only some VA banks required this parameter.
 
 <aside class="warning">
-Note: For Permata(013) and CIMB(022) VA (and Mandiri(008) for some user), the only operation permitted when updating VA is to deactivate it by setting trx_expiration_time as 0.
+Note: For Permata(013) and CIMB(022) VA (and Mandiri(008) for some user), the only operation permitted when updating VA is to deactivate it by setting expiration_time as 0.
 </aside>
 
 ## Deactivate VA


### PR DESCRIPTION
Fixes a note that mentions wrong field to deactivate a VA

Fixes: https://oyteam.slack.com/archives/CHD9AR5FX/p1718945667264229