### PR TITLE
[Fix] Docker image not found when running locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@ version: '3'
 services:
   slate:
     build: .
+    image: local/external-api-docs_slate
     command: ["build"]
     volumes:
       - "./build:/srv/slate/build"
       - "./source:/srv/slate/source"
   slate_serve:
-    image: external-api-docs-slate
+    image: local/external-api-docs_slate
     command: ["serve"]
     ports:
       - "4567:4567"


### PR DESCRIPTION
Making the local image's name fixed

<img width="636" alt="image" src="https://github.com/user-attachments/assets/b2d77d93-4942-416d-a29c-be441258aa80">
