### PR TITLE
[VA] Remove "For all available banks, there is no minimum expiration time."

### DIFF
--- a/source/includes/static_va.md.erb
+++ b/source/includes/static_va.md.erb
@@ -2267,8 +2267,6 @@ Note: For payments and inquiries involving a BSI VA using BSI Mobile or Banking 
 | SMBC                   | 213                                            | Open Amount, Closed Amount                     | Supported                                      | -                                              |
 | BSI (Bank Syariah Indonesia)| 451                                       | Closed Amount                                  | Not Supported                                  | 99999 minutes                                  |
 
-For all available banks, there is no minimum expiration time.
-
 ## List of Documents
 To enable VA Bank BCA, we need partner to send documents using email, directly to our business representative.
 


### PR DESCRIPTION
Remove `For all available banks, there is no minimum expiration time.` as it's no longer relevant