### PR TITLE
[API Docs][Docs Changelog] remove external api docs changelog

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -37,7 +37,6 @@ includes:
   - api_account_linking
   - transaction_detail
   - timeout
-  - docs_changelog
 
 search: true
 


### PR DESCRIPTION
remove api docs changelog as it is not used anymore and could mislead or give wrong info to user that we haven't updated our changelog
<img width="863" height="422" alt="image" src="https://github.com/user-attachments/assets/862a8d63-5bd5-4f6a-a7ef-54a348da956a" />
